### PR TITLE
Fixing debug-print for parameter "-p"

### DIFF
--- a/logrotten.c
+++ b/logrotten.c
@@ -88,6 +88,7 @@ int main(int argc, char* argv[] )
 {
   int length, i = 0;
   int j = 0;
+  int z = 0;
   int index = 0;
   int fd;
   int wd;
@@ -177,7 +178,10 @@ int main(int argc, char* argv[] )
 
   index = j+1;
 
-  p = &logfile[index];
+  for(z=strlen(payloadfile); (payloadfile[z] != '/') && (z != 0); z--);
+  if (strstr(payloadfile, "/"))
+    z++;
+  p = &payloadfile[z+1];
 
   logpath = alloca(strlen(logfile)*sizeof(char));
   logpath2 = alloca((strlen(logfile)+2)*sizeof(char));
@@ -215,7 +219,7 @@ int main(int argc, char* argv[] )
   	printf("logpath2: %s\n",logpath2);
   	printf("targetpath: %s\n",targetpath);
   	printf("targetdir: %s\n",targetdir);
-  	printf("p: %s\n",p);
+  	printf("payloadfile: %s\n",p);
   }
 
   /*checking for error*/


### PR DESCRIPTION
Change in behavior:
- Lines 91, 181-184: Previously running "/home/user/logrotten -d -p /home/user/payload /home/user/.logs_backup/moodle_access" would yield a debug output of
		logfile: /home/user/.logs_backup/moodle_access
		[...]
		p: moodle_access
where clearly "p" should display "payload". Lines 182, 183 are necessary, because otherwise a relative path to payload (by calling "./logrotten -d -p payload ./.logs_backup/moodle_access") would just yield "ayload" (without the "p"). I'd assume, the same issue could arise for some of the other parameters, if their path does not contain a "/" (the parameter "index" is set to "j+1" unconditionally).

Cosmetic change:
- Line 222: Modified the debug-print to display "payloadfile" instead of "p", as every other parameter is displayed by its long name.